### PR TITLE
Anpassung für die Kommunikation mit DMS d.3

### DIFF
--- a/app/helpers/requests_helper.rb
+++ b/app/helpers/requests_helper.rb
@@ -93,6 +93,6 @@ module RequestsHelper
         gsub('{ks_str}', street).
         gsub('{ks_hnr}', housenumber).
         gsub('{ks_hnr_z}', housenumber_addition).
-        gsub('{ks_eigentuemer}', request.extended_attributes.property_owner)
+        gsub('{ks_eigentuemer}', request.extended_attributes.property_owner.truncate(254, omission: '…'))
   end
 end


### PR DESCRIPTION
Länge eines Wertes begrenzen, um Feldlänge in DMS _d.3_ nicht zu überschreiten