### PR TITLE
Change LogLocation back to log/<ENV>.log

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -44,9 +44,9 @@ Rails.application.configure do
   # config.force_ssl = true
 
   # Log to STDOUT by default
-  config.logger = ActiveSupport::Logger.new(STDOUT)
-    .tap  { |logger| logger.formatter = ::Logger::Formatter.new }
-    .then { |logger| ActiveSupport::TaggedLogging.new(logger) }
+  # config.logger = ActiveSupport::Logger.new(STDOUT)
+  #   .tap  { |logger| logger.formatter = ::Logger::Formatter.new }
+  #   .then { |logger| ActiveSupport::TaggedLogging.new(logger) }
 
   # Prepend all log lines with the following tags.
   config.log_tags = [ :request_id ]


### PR DESCRIPTION
Nutzung der ursprünglichen Logfiles, analog zum Backoffice ([#417](https://github.com/bfpi/klarschiff-backoffice/pull/417)).