### PR TITLE
jquery-ui-rails wieder aus den offiziellen RubyGems Quellen nutzen

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ gem 'coffee-rails'
 
 # Use jquery as the JavaScript library
 gem 'jquery-rails'
-gem 'jquery-ui-rails', github: 'jquery-ui-rails/jquery-ui-rails', tag: 'v7.0.0'
+gem 'jquery-ui-rails'
 gem 'jquery-form-rails'
 gem 'bootstrap', '~> 5.1.3' # CSS variable usage in v5.2.x is incomplete until Bootstrap 6
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,3 @@
-GIT
-  remote: https://github.com/jquery-ui-rails/jquery-ui-rails.git
-  revision: 413265e81f790f795239e07e7e25e01429b2f18d
-  tag: v7.0.0
-  specs:
-    jquery-ui-rails (7.0.0)
-      railties (>= 3.2.16)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -144,6 +136,8 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
+    jquery-ui-rails (7.0.0)
+      railties (>= 3.2.16)
     listen (3.9.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -288,7 +282,7 @@ DEPENDENCIES
   jbuilder (~> 2.5)
   jquery-form-rails
   jquery-rails
-  jquery-ui-rails!
+  jquery-ui-rails
   listen
   net-ldap
   oj


### PR DESCRIPTION
Das Pinning auf die Version v7.0.0 direkt im GitHub kann entfallen, da sie mittlerweile bei RubyGems veröffentlicht wurde und dort verfügbar ist.