### PR TITLE
Rückführung `jquery-ui-rails` auf originales Gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ gem 'coffee-rails'
 
 # Use jquery as the JavaScript library
 gem 'jquery-rails'
-gem 'jquery-ui-rails-dox-fork', require: 'jquery-ui-rails'
+gem 'jquery-ui-rails'
 gem 'jquery-form-rails'
 gem 'bootstrap', '~> 5.1.3' # CSS variable usage in v5.2.x is incomplete until Bootstrap 6
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -131,7 +131,7 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
-    jquery-ui-rails-dox-fork (7.0.2)
+    jquery-ui-rails (8.0.0)
       railties (>= 3.2.16)
     listen (3.9.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
@@ -283,7 +283,7 @@ DEPENDENCIES
   jbuilder (~> 2.5)
   jquery-form-rails
   jquery-rails
-  jquery-ui-rails-dox-fork
+  jquery-ui-rails
   listen
   net-ldap
   oj


### PR DESCRIPTION
Nach Aktualisierung der Abhängigkeiten im Original-Gem können wir wieder darauf zurückschwenken.

https://github.com/jquery-ui-rails/jquery-ui-rails/pull/157