### PR TITLE
Redmine #4874: Fallback für Icons bei fehlendem Service

### DIFF
--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -89,8 +89,9 @@ class Request < ActiveResource::Base
   end
 
   private
+
   def icon
-    "png/#{ attributes[:type] || service.type }-#{ icon_color }" if service
+    "png/#{attributes[:type] || service&.type || :blank}-#{icon_color}"
   end
 
   def icon_color

--- a/app/views/observations/index.xml.builder
+++ b/app/views/observations/index.xml.builder
@@ -7,7 +7,7 @@ xml.rss version: '2.0', 'xmlns:atom': 'http://w3.org/2005/Atom', 'xmlns:georss':
     xml.description t(".feed_description#{ '_observation' if @key.present? }", name: Settings::Client.name, city_long: Settings::Client.city_long)
     xml.language 'de-de'
     @requests.each do |r|
-      xml.item do 
+      xml.item do
         xml.title "##{r.id} #{ t(r.service.type, scope: 'service.types', count: 1) } (#{ r.service.group } – #{ r.service })"
         xml.description do
           html_cont = <<-HTML


### PR DESCRIPTION
Nutzung des leeren Icons falls die Kategorie nicht bestimmt werden kann